### PR TITLE
Update PreparedStatement usages

### DIFF
--- a/src/AspNet.Identity.Cassandra/AspNet.Identity.Cassandra/AspNet.Identity.Cassandra.csproj
+++ b/src/AspNet.Identity.Cassandra/AspNet.Identity.Cassandra/AspNet.Identity.Cassandra.csproj
@@ -57,11 +57,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AsyncLazy.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Entities\CassandraUser.cs" />
     <Compile Include="Entities\CassandraUserClaim.cs" />
     <Compile Include="Entities\CassandraUserLogin.cs" />
     <Compile Include="Entities\CassandraUserRole.cs" />
+    <Compile Include="HelperExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Store\CassandraUserStore.cs" />
   </ItemGroup>

--- a/src/AspNet.Identity.Cassandra/AspNet.Identity.Cassandra/AsyncLazy.cs
+++ b/src/AspNet.Identity.Cassandra/AspNet.Identity.Cassandra/AsyncLazy.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace AspNet.Identity.Cassandra
+{
+    /// <summary>
+    /// Utility class for combining async (Task&lt;T&gt;) with Lazy&lt;T&gt;.  Can be awaited.
+    /// </summary>
+    internal class AsyncLazy<T> : Lazy<Task<T>>
+    {
+        public AsyncLazy(Func<Task<T>> taskFactory, bool startNewTaskForFactoryMethod = false)
+            : base(startNewTaskForFactoryMethod ? () => StartNewTask(taskFactory) : taskFactory)
+        {
+        }
+
+        public ConfiguredTaskAwaitable<T>.ConfiguredTaskAwaiter GetAwaiter()
+        {
+            // Since we're using this class in the context of our library, always use ConfigureAwait(false) with the Task
+            return Value.ConfigureAwait(false).GetAwaiter();
+        }
+
+        private static Task<T> StartNewTask(Func<Task<T>> taskFactory)
+        {
+            return Task.Factory.StartNew(taskFactory).Unwrap();
+        }
+    }
+}

--- a/src/AspNet.Identity.Cassandra/AspNet.Identity.Cassandra/HelperExtensions.cs
+++ b/src/AspNet.Identity.Cassandra/AspNet.Identity.Cassandra/HelperExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+using Cassandra;
+
+namespace AspNet.Identity.Cassandra
+{
+    /// <summary>
+    /// Some helpful extension methods.
+    /// </summary>
+    internal static class HelperExtensions
+    {
+        /// <summary>
+        /// Wraps the BeginPrepare/EndPrepare methods with Task so it can be used with async/await.
+        /// </summary>
+        public static Task<PreparedStatement> PrepareAsync(this ISession session, string cqlQuery)
+        {
+            return Task<PreparedStatement>.Factory.FromAsync(session.BeginPrepare, session.EndPrepare, cqlQuery, null);
+        }
+    }
+}


### PR DESCRIPTION
This just updates the usages of PreparedStatements so that we're preparing once, then reusing the instances (so we don't pay the cost of preparing every time).  The CQL/schema didn't change at all.
